### PR TITLE
Add modelIdAttribute getter to Collection

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -74,6 +74,13 @@ class Collection {
   }
 
   /**
+   * Gets the idAttribute used by Model
+   */
+  get modelIdAttribute() {
+    return this.model().prototype.idAttribute();
+  }
+
+  /**
    * Getter for the collection length
    */
   @computed


### PR DESCRIPTION
This one has been added to the local library.  It's used for parsing collections that have a model with a different idAttribute (like uuid) set.