### PR TITLE
Add toJSON() method to Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [set(data, options)](#setdata-options)
     - [Options](#options)
   - [parse(data)](#parsedata)
+  - [clear()](#clear)
   - [toJSON()](#tojson)
   - [get restAttributeDefaults()](#get-restattributedefaults)
   - [idAttribute()](#idattribute)
@@ -230,6 +231,10 @@ class User extends Model {
   }
 }
 ```
+
+### clear()
+
+Clear all the attributes from `attributes` map. Equivalent of calling `model.attributes.clear()`
 
 ### toJSON()
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The default implementation is a no-op, simply passing through the `data`. Overri
 ```javascript
 class User extends Model {
   get restAttributes() {
-    return ['firstName', 'lastName', 'company'];
+    return ['firstName', 'lastName'];
   }
 
   parse(data) {
@@ -226,7 +226,7 @@ class User extends Model {
     // Remove the company from the data.
     delete data.company;
 
-    // First name and last name will be set on the attributes
+    // First name and last name will be set on the attributes. Company will not as it's not defined in restAttributes
     return data;
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [set(data, options)](#setdata-options)
     - [Options](#options)
   - [parse(data)](#parsedata)
+  - [toJSON()](#tojson)
   - [get restAttributeDefaults()](#get-restattributedefaults)
   - [idAttribute()](#idattribute)
   - [cid](#cid)
@@ -229,6 +230,10 @@ class User extends Model {
   }
 }
 ```
+
+### toJSON()
+
+Returns a deep plain object representation of the `attributes` map.
 
 ### get restAttributeDefaults()
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ class User extends Model {
     // Remove the company from the data.
     delete data.company;
 
-    // First name and last name will be set on the attributes. Company will not as it's not defined in restAttributes
+    // First name and last name will be set on the attributes.
     return data;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Model.js
+++ b/src/Model.js
@@ -4,7 +4,7 @@ import pickBy from 'lodash.pickby';
 import pick from 'lodash.pick';
 import omit from 'lodash.omit';
 import forIn from 'lodash.forin';
-import { observable, action, runInAction } from 'mobx';
+import { observable, action, runInAction, toJS } from 'mobx';
 import request from 'axios';
 
 // Throw an error when a URL is needed, and none is supplied.
@@ -236,7 +236,14 @@ class Model {
    */
   @action
   pick(properties) {
-    return pick(this.attributes, properties);
+    return pick(this.toJSON(), properties);
+  }
+
+  /**
+   * Return a plain object representation of the attributes map
+   */
+  toJSON() {
+    return toJS(this.attributes);
   }
 
   /**

--- a/src/Model.js
+++ b/src/Model.js
@@ -299,7 +299,7 @@ class Model {
     );
 
     // Save reference to the current atributes
-    const originalAttributes = this.attributes.toJSON();
+    const originalAttributes = this.toJSON();
 
     // Strip out attributes not defined in the restAttributes map
     if (options.stripNonRest) {
@@ -364,7 +364,7 @@ class Model {
       options
     );
 
-    const originalAttributes = this.attributes.toJSON();
+    const originalAttributes = this.toJSON();
 
     if (data) {
       if (!options.notAttributes) {

--- a/src/Model.js
+++ b/src/Model.js
@@ -234,7 +234,6 @@ class Model {
   /**
    * Picks properties and returns them as an object.
    */
-  @action
   pick(properties) {
     return pick(this.toJSON(), properties);
   }

--- a/tests/Model.test.js
+++ b/tests/Model.test.js
@@ -1158,4 +1158,42 @@ describe('Model', () => {
       expect(collection.at(0).deleting).toBeFalsy();
     });
   });
+
+  describe('toJSON method', () => {
+    it("Returns a plain object representation of the model's attributes", () => {
+      class SubModel extends Model {
+        get restAttributes() {
+          return ['name', 'projects'];
+        }
+      }
+
+      const newModel = new SubModel({
+        name: 'New company',
+        projects: [
+          {
+            id: 1,
+            name: 'Project 1'
+          },
+          {
+            id: 2,
+            name: 'Project 2'
+          }
+        ]
+      });
+
+      expect(newModel.toJSON()).toEqual({
+        name: 'New company',
+        projects: [
+          {
+            id: 1,
+            name: 'Project 1'
+          },
+          {
+            id: 2,
+            name: 'Project 2'
+          }
+        ]
+      });
+    });
+  });
 });


### PR DESCRIPTION
* Adds a `toJSON()` helper method to Model.  This uses Mobx `toJS()` to return a deep plain object representation of the `attributes` map.

* Changes the `create` and `save` methods to call the `toJSON()` method when saving a copy of `originalAttributes`.  

* Also adds documentation for `Model.clear()`