### PR TITLE
Model types with different id attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -73,8 +73,8 @@ class Collection {
   /**
    * Gets idAttribute used by Model
    */
-  get modelIdAttribute() {
-    return this.model().prototype.idAttribute();
+  getModelIdAttribute(type) {
+    return this.model(type).prototype.idAttribute();
   }
 
   /**
@@ -184,7 +184,7 @@ class Collection {
     }
 
     models.forEach(data => {
-      const model = this.get(data[this.modelIdAttribute]);
+      const model = this.get(data[this.getModelIdAttribute(data.type)]);
 
       if (model && options.merge) model.set(data, options);
 
@@ -220,8 +220,8 @@ class Collection {
    */
   @action
   getOrAdd(attributes) {
-    if (this.get(attributes[this.modelIdAttribute]))
-      return this.get(attributes[this.modelIdAttribute]);
+    if (this.get(attributes[this.getModelIdAttribute(attributes.type)]))
+      return this.get(attributes[this.getModelIdAttribute(attributes.type)]);
 
     return this.pushModels(attributes)[0];
   }
@@ -231,7 +231,7 @@ class Collection {
    */
   @action
   updateOrAdd(attributes) {
-    let model = this.get(attributes[this.modelIdAttribute]);
+    let model = this.get(attributes[this.getModelIdAttribute(attributes.type)]);
 
     if (model) {
       model.set(attributes);
@@ -252,7 +252,9 @@ class Collection {
     this.setRequestLabel('saving', true);
 
     arrayAttributes.forEach(attributes => {
-      const existingModel = this.get(attributes[this.modelIdAttribute]);
+      const existingModel = this.get(
+        attributes[this.getModelIdAttribute(attributes.type)]
+      );
       if (existingModel) {
         originalAttributes.push(existingModel.attributes.toJS());
         existingModel.set(attributes);
@@ -547,7 +549,7 @@ class Collection {
     const CollectionModel = this.model();
 
     const model = new CollectionModel(
-      { [this.modelIdAttribute]: id },
+      { [this.getModelIdAttribute()]: id },
       this.modelOptions
     );
 


### PR DESCRIPTION
This covers an edge case where a collection instantiates multiple model classes depending on `type` and some have a different `idAttribute` set than the others.  

This is very edge case, but unfortunately something we have to deal with since we are returning `uuid` and `id` for different model types on our Activity APIs. 