### PR TITLE
Replace on setModels by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -172,7 +172,8 @@ class Collection {
         add: true,
         merge: true,
         remove: true,
-        unshift: false
+        unshift: false,
+        replace: true
       },
       options
     );

--- a/src/Model.js
+++ b/src/Model.js
@@ -144,7 +144,7 @@ class Model {
         parse: true,
         stripUndefined: true,
         stripNonRest: true,
-        replace: true
+        replace: false
       },
       options
     );
@@ -170,7 +170,8 @@ class Model {
     }
 
     if (options.replace) {
-      this.attributes.replace(data);
+      this.attributes.clear();
+      this.attributes.merge(data);
     } else {
       this.attributes.merge(data);
     }


### PR DESCRIPTION
Changes `replace` back to being the `default` option for `set`, so that is can be still used directly as `model.set(attributes)` and a merge will be performed.

This PR changes `setModels` on `Collection` to default to `replace:true` when merging/updating existing models. 