### PR TITLE
Version 2.0 Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ Sets a value, or multiple values, on the `attributes` map. The Model's construct
 - `parse` (_Boolean_) - If `{parse: true}` is passed as an **option**, the `data` will first be run through the model's `parse()` method before being `set` on the map. The default for this option is `true`.
 
 - `stripNonRest` (_Boolean_) - If `{stripNonRest: false}` is passed as an **option**, keys that are not specified in `restAttributes` will still be set on the `attributes` map. The default for this option is `true`.
-- `reset` (_Boolean_) - If `{reset: true}` is passed as an **option**, the entire `attributes` map will be reset with the passed in `data` (Equivalent of `attributes.clear()` && `attributes.merge(data)`). The default for this option is `false` which will perform a merge on the attributes (Equivalent of `attributes.merge(data`)). See the [Mobx documentation on Maps](https://mobx.js.org/refguide/map.html#observable-maps) for more information.
+
+- `reset` (_Boolean_) - If `{reset: true}` is passed as an **option**, the entire `attributes` map will be reset with the passed in `data` (Equivalent of `attributes.clear()` && `attributes.merge(data)`). When call this method directly, the default option is `false` which will perform a merge on the attributes (Equivalent of `attributes.merge(data`)). See the [Mobx documentation on Maps](https://mobx.js.org/refguide/map.html#observable-maps) for more information.
 
 ### parse(data)
 
@@ -386,7 +387,7 @@ Calling `model.fetch` will toggle a `fetching` observable property so you can re
 - `params` (Object) - Used to dynamically add query parameters to the url when fetching.
 - `url` (String) - On some occasions it may be desirable to override the `url` for a single request. The request will default to `model.url()` when this is not explicitly configured.
 
-In addition to the above, you can also pass in any options supported by the `set` method and these will be passed through to that method when handling the response from the server. Please note that the `reset` option will be set to `true` by default when calling `model.fetch`.
+In addition to the above, you can also pass in any options supported by the `set` method and these will be passed through to that method when handling the response from the server. Please note that the `reset` option will be `true` by default when calling `model.fetch`.
 
 ```javascript
 class User extends Model {
@@ -571,7 +572,7 @@ If you'd like to customize the behavior, you can configure it with options:
 - `remove` (Boolean)
 - `update`(Boolean)
 
-When using the `update` option, the default behaviour is a full reset of each model's attributes. Pass `merge:true` to override this and keep existing attributes in-tact.
+When using the `update` option, the default behaviour is a full reset of each model's attributes, deleting any keys not specifed in `data`. Pass `merge:true` if you would like to merge in the `data` and keep all existing keys in-tact.
 
 - `merge`(Boolean)
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,13 @@
     - [Options](#options-5)
   - [getOradd(data)](#getoradddata)
   - [remove(models)](#removemodels)
-    - [Options](#options-6)
   - [reset(array)](#resetarray)
   - [url()](#url-1)
   - [CRUD Operations](#crud-operations-1)
   - [fetch(options)](#fetchoptions-1)
-    - [Options](#options-7)
+    - [Options](#options-6)
   - [create(data, options)](#createdata-options)
-    - [Options](#options-8)
+    - [Options](#options-7)
   - [getOrFetch(id, options)](#getorfetchid-options)
 - [Where is it used?](#where-is-it-used)
 - [License](#license)
@@ -207,7 +206,7 @@ Sets a value, or multiple values, on the `attributes` map. The Model's construct
 - `parse` (_Boolean_) - If `{parse: true}` is passed as an **option**, the `data` will first be run through the model's `parse()` method before being `set` on the map. The default for this option is `true`.
 
 - `stripNonRest` (_Boolean_) - If `{stripNonRest: false}` is passed as an **option**, keys that are not specified in `restAttributes` will still be set on the `attributes` map. The default for this option is `true`.
-- `replace` (_Boolean_) - If `{replace: true}` is passed as an **option**, the entire `attributes` map will be replaced with the passed in `data` (Equivalent of `attributes.clear()` && `attributes.set(data)`). The default for this option is `false` which will perform a merge on the attributes (Equivalent of `attributes.merge(data`)). See the [Mobx documentation on Maps](https://mobx.js.org/refguide/map.html#observable-maps) for more information.
+- `reset` (_Boolean_) - If `{reset: true}` is passed as an **option**, the entire `attributes` map will be reset with the passed in `data` (Equivalent of `attributes.clear()` && `attributes.merge(data)`). The default for this option is `false` which will perform a merge on the attributes (Equivalent of `attributes.merge(data`)). See the [Mobx documentation on Maps](https://mobx.js.org/refguide/map.html#observable-maps) for more information.
 
 ### parse(data)
 
@@ -378,7 +377,7 @@ model
 
 ### fetch(options)
 
-Merges the model's `attributes` with data fetched from the server. Useful if the model has never been populated with data, or if you'd like to ensure that you have the latest server state.
+Resets the model's `attributes` with data fetched from the server. Useful if the model has never been populated with data, or if you'd like to ensure that you have the latest server state.
 
 Calling `model.fetch` will toggle a `fetching` observable property so you can respond accordingly to the status of the http `GET` request (e.g. To show a loading animation).
 
@@ -386,6 +385,8 @@ Calling `model.fetch` will toggle a `fetching` observable property so you can re
 
 - `params` (Object) - Used to dynamically add query parameters to the url when fetching.
 - `url` (String) - On some occasions it may be desirable to override the `url` for a single request. The request will default to `model.url()` when this is not explicitly configured.
+
+In addition to the above, you can also pass in any options supported by the `set` method and these will be passed through to that method when handling the response from the server. Please note that the `reset` option will be set to `true` by default when calling `model.fetch`.
 
 ```javascript
 class User extends Model {
@@ -559,15 +560,16 @@ Shortcut property equivalent to `models.length`
 The **set** method performs a "smart" update of the the **models** array with the passed list of models:
 
 - If a model in the list isn't in the collection, it will be added.
-- If a model in the list is in the collection already, its attributes will be merged.
 - If the collection contains any models that aren't in the list, they'll be removed.
+- If a model in the list is in the collection already, its attributes will be updated. The default is a full reset of the model's attributes. Pass `merge:true` to override this.
 
-If you'd like to customize the behavior, you can disable it with options: `{add: false}`, `{remove: false}`, or `{merge: false}`.
+If you'd like to customize the behavior, you can configure it with options:
 
 #### Options
 
 - `add` (Boolean)
 - `remove` (Boolean)
+- `update`(Boolean),
 - `merge`(Boolean)
 
 ### parse(data)
@@ -634,24 +636,19 @@ Get a model from a collection, specified by `index`. Equivalent of `collection.m
 
 Add a model (or an array of models) to the collection. If a Model class is defined, you may also pass raw model data and options, and have them be vivified as instances of the model using the provided options. Returns the updated `models` array.
 
-### getOrAdd(data)
-
-Attempts to find a model with the same `idAttribute` passed in the `data` object and return it. If no pre-existing model is found, it will add the new model, then return it.
-
 #### Options
 
 - `at` Pass `{at: index}` to splice the model into the collection at the specified `index`
 
 You can also pass in any options supported by the `set` method and these will be passed through to that method when adding the new models to the collection.
 
+### getOrAdd(data)
+
+Attempts to find a model with the same `idAttribute` passed in the `data` object and return it. If no pre-existing model is found, it will add the new model, then return it.
+
 ### remove(models)
 
 Remove a model (or an array of models) from the collection. The models object/array can be references to actual models, or raw data objects.
-
-#### Options
-
-- Pass `{at: index}` to splice the model into the collection at the specified index.
-- If you're adding models to the collection that it already contains, they'll be ignored, unless you pass `{merge: true}`, in which case their attributes will be merged into the corresponding models.
 
 ### reset(array)
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ The **set** method performs a "smart" update of the the **models** array with th
 
 - If a model in the list isn't in the collection, it will be added.
 - If the collection contains any models that aren't in the list, they'll be removed.
-- If a model in the list is in the collection already, its attributes will be updated. The default is a full reset of the model's attributes. Pass `merge:true` to override this.
+- If a model in the list is in the collection already, its attributes will be updated.
 
 If you'd like to customize the behavior, you can configure it with options:
 
@@ -569,7 +569,10 @@ If you'd like to customize the behavior, you can configure it with options:
 
 - `add` (Boolean)
 - `remove` (Boolean)
-- `update`(Boolean),
+- `update`(Boolean)
+
+When using the `update` option, the default behaviour is a full reset of each model's attributes. Pass `merge:true` to override this and keep existing attributes in-tact.
+
 - `merge`(Boolean)
 
 ### parse(data)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "2.0-alpha.0",
+  "version": "2.0.0-alpha.0",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "1.1.6-2.0-alpha.0",
+  "version": "2.0-alpha.0",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "1.1.5",
+  "version": "1.1.6-2.0-alpha.0",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -172,9 +172,9 @@ class Collection {
       {
         add: true,
         update: true,
+        merge: false,
         remove: true,
-        unshift: false,
-        merge: false
+        unshift: false
       },
       options
     );
@@ -188,7 +188,7 @@ class Collection {
     models.forEach(data => {
       const model = this.get(data[this.getModelIdAttribute(data.type)]);
 
-      if (model && options.merge)
+      if (model && options.update)
         model.set(data, {
           reset: Boolean(!options.merge)
         });
@@ -211,8 +211,8 @@ class Collection {
         {
           add: true,
           update: false,
-          remove: false,
-          merge: false
+          merge: false,
+          remove: false
         },
         options
       )
@@ -390,8 +390,8 @@ class Collection {
         params: {},
         add: true,
         update: true,
-        remove: true,
-        merge: false
+        merge: false,
+        remove: true
       },
       options
     );

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -132,8 +132,9 @@ class Collection {
     options = Object.assign(
       {
         add: true,
-        merge: true,
-        remove: true
+        update: true,
+        remove: true,
+        merge: false
       },
       options
     );
@@ -170,10 +171,10 @@ class Collection {
     options = Object.assign(
       {
         add: true,
-        merge: true,
+        update: true,
         remove: true,
         unshift: false,
-        replace: true
+        merge: false
       },
       options
     );
@@ -187,7 +188,10 @@ class Collection {
     models.forEach(data => {
       const model = this.get(data[this.getModelIdAttribute(data.type)]);
 
-      if (model && options.merge) model.set(data, options);
+      if (model && options.merge)
+        model.set(data, {
+          reset: Boolean(!options.merge)
+        });
 
       if (!model && options.add) this.pushModels(data, options);
     });
@@ -206,8 +210,9 @@ class Collection {
       Object.assign(
         {
           add: true,
-          merge: false,
-          remove: false
+          update: false,
+          remove: false,
+          merge: false
         },
         options
       )
@@ -384,8 +389,9 @@ class Collection {
         url: this.url(),
         params: {},
         add: true,
-        merge: true,
-        remove: true
+        update: true,
+        remove: true,
+        merge: false
       },
       options
     );
@@ -413,6 +419,7 @@ class Collection {
             runInAction('fetch-success', () => {
               this.set(response.data, {
                 add: options.add,
+                update: options.update,
                 merge: options.merge,
                 remove: options.remove,
                 unshift: options.unshift

--- a/src/Model.js
+++ b/src/Model.js
@@ -338,9 +338,9 @@ class Model {
         response => {
           runInAction('save-success', () => {
             if (options.reset) {
-              this.set(Object.assign({}, data, response.data), options);
-            } else {
               this.set(response.data, options);
+            } else {
+              this.set(Object.assign({}, data, response.data), options);
             }
 
             this.setRequestLabel('saving', false);

--- a/src/Model.js
+++ b/src/Model.js
@@ -149,6 +149,10 @@ class Model {
       options
     );
 
+    if (options.reset) {
+      this.attributes.clear();
+    }
+
     // Set the id immediately if possible
     if (data && data[this.idAttribute()]) {
       this.id = data[this.idAttribute()];
@@ -169,17 +173,7 @@ class Model {
       data = this.stripNonRestAttributes(data);
     }
 
-    if (options.reset) {
-      Object.keys(this.attributes).forEach(key => {
-        if (data[key]) {
-          this.attributes.set(key, data[key]);
-        } else {
-          this.attributes.delete(key);
-        }
-      });
-    } else {
-      this.attributes.merge(data);
-    }
+    this.attributes.merge(data);
 
     return this;
   }

--- a/tests/Collection.test.js
+++ b/tests/Collection.test.js
@@ -307,7 +307,7 @@ describe('Collection', () => {
     });
   });
 
-  describe('setModels action with merge option set to falsy', () => {
+  describe('setModels action with update option set to falsy', () => {
     beforeEach(() => {
       collection = new UserCollection(usersData);
 
@@ -332,7 +332,7 @@ describe('Collection', () => {
             phone: '012345678'
           }
         ],
-        { add: true, merge: false, remove: true }
+        { add: true, update: false, remove: true }
       );
     });
 

--- a/tests/Collection.test.js
+++ b/tests/Collection.test.js
@@ -195,8 +195,9 @@ describe('Collection', () => {
 
       expect(collection.setModels).toHaveBeenCalledWith(usersData, {
         add: true,
-        merge: true,
-        remove: true
+        update: true,
+        remove: true,
+        merge: false
       });
     });
 
@@ -297,7 +298,7 @@ describe('Collection', () => {
             phone: '012345678'
           }
         ],
-        { add: false, merge: true, remove: true }
+        { add: false, update: true, remove: true }
       );
     });
 
@@ -365,7 +366,7 @@ describe('Collection', () => {
             phone: '012345678'
           }
         ],
-        { add: true, merge: true, remove: false }
+        { add: true, update: true, remove: false }
       );
     });
 
@@ -397,6 +398,7 @@ describe('Collection', () => {
       expect(collection.setModels).toHaveBeenCalledWith([modelJSON], {
         add: true,
         remove: false,
+        update: false,
         merge: false
       });
 
@@ -889,8 +891,9 @@ describe('Collection', () => {
 
       expect(collection.set).toHaveBeenCalledWith(companiesData, {
         add: true,
-        merge: true,
-        remove: true
+        update: true,
+        remove: true,
+        merge: false
       });
       expect(collection.fetching).toBeFalsy();
     });
@@ -913,14 +916,15 @@ describe('Collection', () => {
       });
 
       collection
-        .fetch({ add: true, merge: false, remove: false })
+        .fetch({ add: true, update: false, merge: false, remove: false })
         .then(() => {})
         .catch(() => {});
 
       expect(collection.set).toHaveBeenCalledWith(companiesData, {
         add: true,
-        merge: false,
-        remove: false
+        update: false,
+        remove: false,
+        merge: false
       });
     });
 
@@ -948,8 +952,9 @@ describe('Collection', () => {
 
       expect(collection.set).toHaveBeenCalledWith(companiesData, {
         add: true,
-        merge: true,
-        remove: false
+        update: true,
+        remove: false,
+        merge: false
       });
     });
 

--- a/tests/Model.test.js
+++ b/tests/Model.test.js
@@ -591,7 +591,7 @@ describe('Model', () => {
         {
           wait: true,
           stripNonRest: true,
-          replace: false,
+          reset: false,
           method: 'patch'
         }
       );
@@ -757,7 +757,7 @@ describe('Model', () => {
 
       expect(model.set).toHaveBeenCalledWith(userData, {
         method: 'patch',
-        replace: false,
+        reset: false,
         stripNonRest: true,
         wait: false
       });


### PR DESCRIPTION
Release candidate for version 2.0.   The goal of this release is to provide more flexibility when updating models from the server.  You can now choose to reset a model's attributes  (clear the attributes map before updating - essentially setting to the exact state on the server) or to perform a merge and keep any existing keys/values pairs that are not specified in the new data.

**Change Log**

* Add new `reset` option to `Model.set`.  Setting this to `true` will clear out the model's attributes before updating with the passed in `data`.   This option can be passed to `save`, `fetch` etc.  This  feature is helpful for working with APIs that omit keys that are either `undefined` or `null`. 

* Rename `merge` option for `Collection.set` to `update`.   Setting this to `true` will update existing models when updating a collection with data (same behaviour as before).

* Add new `merge` option to `Collection.set`.  Setting this to `false` will mean the contents of any existing models are cleared and reset only with the new values.  The default is `false` (A full reset).

Please view the updated README for up to date documentation on these changes. 