### PR TITLE
Revert "Switch to Redaxios"

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ class User extends Model {
     return ['title', 'firstName', 'lastName'];
   }
 
-  get restAttributeDefaults() {
+  get resetAttributeDefaults() {
     return {
       title: 'Dr'
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/rakenapp/mobx-mx#readme",
   "dependencies": {
+    "axios": "^0.18.1",
     "lodash.difference": "^4.5.0",
     "lodash.forin": "^4.4.0",
     "lodash.isempty": "^4.4.0",
@@ -35,7 +36,6 @@
     "lodash.result": "^4.5.2",
     "mobx": "4.13.1",
     "querystringify": "^2.1.1",
-    "redaxios": "^0.2.0",
     "uuid-v4": "^0.1.0"
   },
   "devDependencies": {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash.isempty';
 import difference from 'lodash.difference';
 import { action, observable, computed, runInAction } from 'mobx';
-import request, { CancelToken } from 'redaxios';
+import request, { CancelToken } from 'axios';
 import qs from 'querystringify';
 import Model from './Model';
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -5,7 +5,7 @@ import pick from 'lodash.pick';
 import omit from 'lodash.omit';
 import forIn from 'lodash.forin';
 import { observable, action, runInAction, toJS } from 'mobx';
-import request from 'redaxios';
+import request from 'axios';
 
 // Throw an error when a URL is needed, and none is supplied.
 const urlError = () => {

--- a/tests/Collection.test.js
+++ b/tests/Collection.test.js
@@ -1,4 +1,4 @@
-import request from 'redaxios';
+import request from 'axios';
 import Collection from '../src/Collection';
 import Model from '../src/Model';
 

--- a/tests/Model.test.js
+++ b/tests/Model.test.js
@@ -1,5 +1,5 @@
 import omit from 'lodash.omit';
-import request from 'redaxios';
+import request from 'axios';
 import { observable } from 'mobx';
 import Model from '../src/Model';
 import Collection from '../src/Collection';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3416,11 +3416,6 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redaxios@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/redaxios/-/redaxios-0.2.0.tgz#acf6f50607d232cda407d1e06f4bd043adba1992"
-  integrity sha512-lrDld2bVWIBrW+S1HPMyP8OvEtpHPIfmXyW7T7xTox1SM4/M3aC5X55xa2vRR3LZHwCvpMQAgCye8IyICzkKpA==
-
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"


### PR DESCRIPTION
Reverts rakenapp/mobx-mc#27

I was a little trigger happy with this change.  Any projects already using axios will not be able to upgrade if they are using features like `defaults.baseUrl`.   I will keep an eye on the progress of redaxios. 