### PR TITLE
Don't clear attributes map on fetch by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ You can pass in Axios specific configuration by passing an additional `axios` ob
 ```javascript
 model
   .fetch({
-    axiosOptions: {
+    axios: {
       timeout: 1000
     }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Model.js
+++ b/src/Model.js
@@ -253,7 +253,7 @@ class Model {
     // Merge in the any options with the default
     options = Object.assign(
       {
-        reset: true
+        reset: false
       },
       options
     );

--- a/tests/Model.test.js
+++ b/tests/Model.test.js
@@ -524,7 +524,7 @@ describe('Model', () => {
         .catch(() => {});
 
       expect(model.set).toHaveBeenCalledWith(userData, {
-        reset: true
+        reset: false
       });
     });
 


### PR DESCRIPTION
Sets the default `reset` option of `model.fetch()` to `false`.  This means that if you want to fetch from an API using e.g. sparse fieldsets, or just fetch a minimal set or attributes, the full attributes map will not be cleared out first.  You can pass `reset: true` if you wish to fully reset the attributes map on fetch (clear then merge operation).

Also fixes a typo in the ReadMe.  `axiosOptions` should be `options.axios`