### PR TITLE
Enable Cancel Request (Axios) for Model.fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/Collection.test.js
+++ b/tests/Collection.test.js
@@ -621,6 +621,7 @@ describe('Collection', () => {
         expect(request.get).toHaveBeenCalledWith(
           'jsonapi/users/3c59d5f0-d958-4cd5-a81b-2a87d835921f',
           {
+            cancelToken: expect.anything(),
             params: {}
           }
         );
@@ -676,6 +677,7 @@ describe('Collection', () => {
         expect(request.get).toHaveBeenCalledWith(
           'jsonapi/users/3c59d5f0-d958-4cd5-a81b-2a87d835921f',
           {
+            cancelToken: expect.anything(),
             params: {}
           }
         );

--- a/tests/Model.test.js
+++ b/tests/Model.test.js
@@ -139,6 +139,7 @@ describe('Model', () => {
       model.fetch();
 
       expect(request.get).toHaveBeenCalledWith('/api/v1/users/2017-11-13', {
+        cancelToken: expect.anything(),
         params: {}
       });
     });
@@ -466,7 +467,10 @@ describe('Model', () => {
         .then(() => {})
         .catch(() => {});
 
-      expect(request.get).toHaveBeenCalledWith(model.url(), { params: {} });
+      expect(request.get).toHaveBeenCalledWith(model.url(), {
+        cancelToken: expect.anything(),
+        params: {}
+      });
     });
 
     it('Calls a get request with the url passed in though options', () => {
@@ -480,6 +484,7 @@ describe('Model', () => {
         .catch(() => {});
 
       expect(request.get).toHaveBeenCalledWith('/api/users/1', {
+        cancelToken: expect.anything(),
         params: {}
       });
     });
@@ -497,6 +502,7 @@ describe('Model', () => {
         .catch(() => {});
 
       expect(request.get).toHaveBeenCalledWith(model.url(), {
+        cancelToken: expect.anything(),
         params: { included: 'companies' }
       });
     });


### PR DESCRIPTION
This PR enables the ability to cancel the request for `Model.fetch` .  Note that `Collection` already supports this. 

This can be useful in a UI where user selection makes a request.  If the user was to make two changes in succession, the first request fired could be cancelled.

```
model.fetch(); //  GET Request starts
model.cancelRequest(); //. GET request cancelled.
```

I'm using the generic `cancelRequest()` method name so that we can apply it the other CRUD methods if required.