### PR TITLE
Make cancelRequest a method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -582,11 +582,10 @@ class Collection {
   /**
    * Cancel the current request
    */
-  @action
-  cancelRequest = () => {
+  cancelRequest() {
     this.requestCanceller &&
       this.requestCanceller('Operation canceled by the user.');
-  };
+  }
 }
 
 export default Collection;

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -431,7 +431,9 @@ class Collection {
           error => {
             runInAction('fetch-error', () => {
               this.setRequestLabel('fetching', false);
-              reject(error);
+              if (!request.isCancel(error)) {
+                reject(error);
+              }
             });
           }
         );

--- a/src/Model.js
+++ b/src/Model.js
@@ -485,11 +485,10 @@ class Model {
   /**
    * Cancel the current request
    */
-  @action
-  cancelRequest = () => {
+  cancelRequest() {
     this.requestCanceller &&
       this.requestCanceller('Operation canceled by the user.');
-  };
+  }
 }
 
 export default Model;

--- a/src/Model.js
+++ b/src/Model.js
@@ -285,7 +285,9 @@ class Model {
           error => {
             runInAction('fetch-error', () => {
               this.setRequestLabel('fetching', false);
-              reject(error);
+              if (!request.isCancel(error)) {
+                reject(error);
+              }
             });
           }
         );


### PR DESCRIPTION
Further fix from the previous PR here: https://github.com/rakenapp/mobx-mc/pull/30

This makes `cancelRequest()` a standard method rather than an `action` as it does not modify any observable state. 

This change also prevents an `Uncaught (in promise) TypeError` message when the request is cancelled, by checking if the request was purposely cancelled before called `reject(error)`