### PR TITLE
Pass options to model create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-mc",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Mobx Store Model-Collection Library",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -475,10 +475,9 @@ class Collection {
       model
         .create(
           null,
-          {
+          Object.assign(options, {
             url: options.url ? options.url : this.url()
-          },
-          options
+          })
         )
         .then(
           (savedModel, response) => {

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -474,7 +474,7 @@ class Collection {
       // Model can create itself
       model
         .create(
-          null,
+          data,
           Object.assign(options, {
             url: options.url ? options.url : this.url()
           })

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -473,9 +473,13 @@ class Collection {
 
       // Model can create itself
       model
-        .create(null, {
-          url: options.url ? options.url : this.url()
-        })
+        .create(
+          null,
+          {
+            url: options.url ? options.url : this.url()
+          },
+          options
+        )
         .then(
           (savedModel, response) => {
             runInAction('create-success', () => {

--- a/src/Model.js
+++ b/src/Model.js
@@ -380,6 +380,7 @@ class Model {
       {
         wait: false,
         method: 'post',
+        stripNonRest: true,
         notAttributes: false
       },
       options
@@ -396,7 +397,7 @@ class Model {
     }
 
     if (!options.wait) {
-      this.set(data);
+      this.set(data, options);
     } else {
       this.setRequestLabel('saving', true);
     }
@@ -407,7 +408,7 @@ class Model {
         .then(
           response => {
             runInAction('create-success', () => {
-              this.set(response.data);
+              this.set(response.data, options);
               this.setRequestLabel('saving', false);
               resolve(this);
             });

--- a/tests/Model.test.js
+++ b/tests/Model.test.js
@@ -1032,7 +1032,12 @@ describe('Model', () => {
         .then(() => {})
         .catch(() => {});
 
-      expect(model.set).toHaveBeenCalledWith(userData);
+      expect(model.set).toHaveBeenCalledWith(userData, {
+        method: 'post',
+        notAttributes: false,
+        stripNonRest: true,
+        wait: false
+      });
     });
 
     it('resets to the original attributes on failed save to server if wait option is falsy', () => {


### PR DESCRIPTION
`Collection.create` is not currently passing through `options` to `Model.create` so it's not possible to to e.g

```
myCollection.create(attributes, { stripNonRest: false})
```